### PR TITLE
Sync append log file

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -50,9 +50,9 @@ io.on('connection', (socket) => {
   app.post(
     '/logger',
     basicAuth(process.env.HTTP_AUTH_USER, process.env.HTTP_AUTH_PASSWORD),
-    async (req, res) => {
+    (req, res) => {
       try {
-        await fs.appendFile(`${__dirname}/logs/${moment().format('DD.MM.YYYY')}.log`, req.body.dataLog + '\n');
+        fs.appendFileSync(`${__dirname}/logs/${moment().format('DD.MM.YYYY')}.log`, req.body.dataLog + '\n');
         socket.broadcast.emit('get-log', req.body.dataLog);
         res.send({
           saved: true


### PR DESCRIPTION
`fs.appendFile(path, data[, options], callback)` - колбечит, а не возвращает промис, await не будет тут ничего ждать.